### PR TITLE
피튜닝 실습시 numpy 버전 이슈로 인한 수정

### DIFF
--- a/8.GPT3/8.4.gpt2_p_tuning_NSMC.ipynb
+++ b/8.GPT3/8.4.gpt2_p_tuning_NSMC.ipynb
@@ -16,7 +16,11 @@
    },
    "source": [
     "## 환경 준비\n",
-    "(Google Colab 환경에서 사용하세요)"
+    "(Google Colab 환경에서 사용하세요)\n",
+    "\n",
+    "**설치 후 Colab 또는 Jupyter 노트북 런타임 또는 커널 환경을 반드시 재시작 해주세요.\n",
+    "\n",
+    "(numpy 버전 이슈로 인해 설치후 바로 실행할 시 tensorflow 학습 시작전에 에러가 발생합니다.)"
    ]
   },
   {
@@ -32,8 +36,7 @@
    "outputs": [],
    "source": [
     "!wget https://raw.githubusercontent.com/NLP-kr/tensorflow-ml-nlp-tf2/master/requirements.txt -O requirements.txt\n",
-    "!pip install -r requirements.txt\n",
-    "!pip install tensorflow==2.2.0"
+    "!pip install -r requirements.txt"
    ]
   },
   {
@@ -207,7 +210,7 @@
     "        last_hidden_states, _ = self.gpt2({'inputs_ids': None, 'inputs_embeds': inputs_embeds, 'attention_mask': attention_mask})\n",
     "        output = last_hidden_states[:, -1, :]\n",
     "\n",
-    "        return outputs"
+    "        return output"
    ]
   },
   {


### PR DESCRIPTION
### 내용

- numpy 버전이 1.21로 올라가면서 tf에서 `NotImplementedError: Cannot convert a symbolic Tensor ...... to a numpy array` 와 같은 에러를 냄
- 기존 실습 파일에서는 이상이 없고 피튜닝에서 이상이 있는것으로 보임 (프롬프트 임베딩 레이어에서 이슈가 있을 것으로 추정)
- numpy 버전을 기존과 동일하게 1.16.2로 낮추도록 해두었으나 실습 환경을 재시작 해야하는 문제가 있음

### 수정 내용

- 설치시 커널을 재시작해야한다는 설명문구 추가
- 코드에 변수명 버그가 있어 수정